### PR TITLE
Add the scrollToLine function to the highlight function.

### DIFF
--- a/js/jerry-client.js
+++ b/js/jerry-client.js
@@ -496,6 +496,7 @@ Session.prototype.highlightCurrentLine = function(lineNumber) {
   this.marker.executed = this.editor.session.addMarker(new Range(lineNumber, 0, lineNumber, 1), "execute-marker", "fullLine");
 
   this.editor.session.addGutterDecoration(lineNumber, "execute-gutter-cell-marker");
+  this.editor.scrollToLine(lineNumber, true, true, function () {});
   this.marker.lastMarked = lineNumber;
 }
 


### PR DESCRIPTION
When the debugger stoppes on a line, the editor will mark that line with a solid border and will scroll to that line now.